### PR TITLE
Revert "Bump chart.js from 2.9.4 to 3.8.2 in /react-demo"

### DIFF
--- a/react-demo/package.json
+++ b/react-demo/package.json
@@ -12,7 +12,7 @@
         "@testing-library/user-event": "^12.1.10",
         "@types/jest": "^28.1.6",
         "@types/node": "^18.6.1",
-        "chart.js": "^3.8.2",
+        "chart.js": "^2.8.0",
         "deepcopy": "^2.0.0",
         "@types/react": "^17.0.0",
         "@types/react-dom": "^17.0.0",

--- a/react-demo/yarn.lock
+++ b/react-demo/yarn.lock
@@ -3289,11 +3289,6 @@ chart.js@^2.8.0:
     chartjs-color "^2.1.0"
     moment "^2.10.2"
 
-chart.js@^3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.8.2.tgz#e3ebb88f7072780eec4183a788a990f4a58ba7a1"
-  integrity sha512-7rqSlHWMUKFyBDOJvmFGW2lxULtcwaPLegDjX/Nu5j6QybY+GCiQkEY+6cqHw62S5tcwXMD8Y+H5OBGoR7d+ZQ==
-
 chartjs-color-string@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz#1df096621c0e70720a64f4135ea171d051402f71"


### PR DESCRIPTION
Reverts brightlayer-ui/chartjs#88